### PR TITLE
Revert "install python3-distutils"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,7 +109,6 @@
     - python3.6
     - python3.6-venv
     - python3.6-dev
-    - python3-distutils
     - libffi-dev
     - libssl-dev
     - virtualenv


### PR DESCRIPTION
This reverts commit 7655f7f54db396e840ed805940e03115d9499d76.

Now it breaks installation, because of conflicts. It works without it.